### PR TITLE
Wording and broken link

### DIFF
--- a/source/_docs/installation/synology.markdown
+++ b/source/_docs/installation/synology.markdown
@@ -11,16 +11,14 @@ redirect_from: /getting-started/installation-synology/
 ---
 
 <p class="note warning">
-Synology only provides [Python 3.5.1](https://www.synology.com/en-global/dsm/packages/py3k), which is not compatible with Home Assistant 0.65.0 or later. Until Synology offer an updated version of Python, Home Assistant 0.64 is the most recent version that will be able to be installed. If you want to run newer Home Assistant versions, you will need to make a new Python 3 package, which will be detailed in this guide. Otherwise you can follow the instructions "[Using older Python 3 provided by Synology](#-linkable_title-using-older-python-3-provided-by-synology-)" way below of the document.
+Synology only provides [Python 3.5.1](https://www.synology.com/en-global/dsm/packages/py3k), which is not compatible with Home Assistant 0.65.0 or later. Until Synology offer an updated version of Python, Home Assistant 0.64 is the most recent version that will be able to be installed. If you want to run newer Home Assistant versions, you will need to make a new Python 3 package, which will be detailed in this guide. Otherwise you can follow the instructions "[Using older Python 3 provided by Synology](#using-older-python-3-provided-by-synology)" at the bottom of this document.
 </p>
 
 There are 2 alternatives, when using Home Assistant on Synology NAS:
 1. Using Docker (Recommended)
 2. Directly running on DSM
 
-Option 1 is described on the [Docker installation page](/docs/installation/docker/#synology-nas), whereas Option 2 is described below.  
-Our recommendation is to run Home Assistant on Docker (If available) or a Raspberri Pi, as the instructions written below are a bit involved.
-
+Option 1 is described on the [Docker installation page](/docs/installation/docker/#synology-nas), whereas Option 2 is described below. Our recommendation is to run Home Assistant on Docker (If available) or a Raspberri Pi, as the instructions written below are a bit involved.
 
 The following configuration has been tested on [Synology DS115j](https://www.synology.com/en-global/products/DS115j) running DSM 6.2.1-23824 Update 1.
 
@@ -103,8 +101,7 @@ Make the Python 3 package for your Synology NAS model, please modify `docker run
 ```bash
 # sudo docker run -it -v ~/spksrc:/spksrc -w /spksrc synocommunity/spksrc bash -c 'make clean && make setup && make -C spk/python3 arch-XXXX'
 ```
-After the compilation is done, you can find the Python 3 package at "*~/spksrc/packages/python3_XXXX.spk*".
-It should be named something like "python3_armada370-6.1_3.5.5-7.spk", of course with a possibly different architecture and version.
+After the compilation is done, you can find the Python 3 package at "*~/spksrc/packages/python3_XXXX.spk*". It should be named something like "python3_armada370-6.1_3.5.5-7.spk", of course with a possibly different architecture and version.
 
 If you want to remove the Docker container downloaded by `docker run` to save drive space, run the following command:
 ```bash


### PR DESCRIPTION
Just made some minor changes that I saw.

I also have a couple questions:

The code snippets include the leading character '#' or '$' and I assume that was intentional. It breaks just being able to copy paste by triple-clicking, since I have to omit the leading character. And prevents copy/pasting multiple lines at once. However, depending on your view, that can be intended since the "right" way is to just retype it all yourself. 😄 

The step-by-step instructions are using un-ordered lists. Are they intentionally not ordered? In my opinion, a step-by-step should use an ordered list since things are done in order.

Thanks.

**Description:**
Fixed the hyperlink to the old instructions
Re-worded "way below the document" to "at the bottom of this document"
Remove a couple newlines which are reflected when the page is rendered with jeckyll (I think they are unintentional, on the rendered netlify I think they're jarring).

**Pull request in [home-assistant](https://github.com/home-assistant/home-assistant) (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [ ] Branch: `next` is for changes and new documentation that will go public with the next [home-assistant](https://github.com/home-assistant/home-assistant) release. Fixes, changes and adjustments for the current release should be created against `current`.
- [ ] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
